### PR TITLE
docs: add comprehensive README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,53 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Gender Reveal Party
 
-## Getting Started
+An interactive gender reveal party application built with Next.js and React. The host launches a game session and shares a link for players to join from their own devices. Participants compete in two mini-games—**Quiz** and **Termo**—before the big gender reveal.
 
-First, run the development server:
+## Technologies
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- **Next.js 15** and **React 19** for the web interface and routing
+- **TypeScript** for static typing
+- **Prisma ORM** with **PostgreSQL**
+- **Tailwind CSS** for styling
+- **ws** for WebSocket communication
+
+## Project Structure
+
+```
+src/
+├─ app/
+│  ├─ host_session/[session_id]       # Host dashboard
+│  └─ player_session/[session_id]     # Player flow
+│     ├─ quiz                         # Quiz phase
+│     └─ termo                        # Termo phase
+├─ components/                        # Reusable UI pieces
+└─ lib/                               # Client utilities (HTTP, WS, helpers)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### Host Flow
+The host screen orchestrates the session, advances game phases and broadcasts updates over WebSockets.
 
-### Seeding the database
+### Player Flow
+Players join via a session URL and are routed to either the Quiz or Termo sub-pages depending on the current phase.
 
-After setting up your environment and running migrations, populate the database with initial questions:
+## Game Phases
 
-```bash
-npm run prisma:seed
-```
+Phases alternate between multiple Quiz rounds and a word-guessing Termo challenge, followed by a final scoreboard and gender reveal.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- **Quiz**: multiple-choice questions with timers and real-time updates
+- **Termo**: a word puzzle with a custom on-screen keyboard and limited attempts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## WebSocket Server & Deployment
 
-## Learn More
+Vercel's serverless platform lacks native WebSocket support, so a custom Node server (`server.mjs`) is bundled to handle WebSocket connections alongside Next.js routing.
 
-To learn more about Next.js, take a look at the following resources:
+## Database
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Prisma schema defines sessions, questions, answers and game phases. A seed script pre-populates sample quiz questions.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-
-
-# Create postgres database locally
+### Create Database and Run Migrations
 
 ```bash
+# Create Postgres database & user
 sudo -u postgres psql
 CREATE DATABASE gender_reveal;
 CREATE USER gender_reveal_user WITH PASSWORD 'pass';
@@ -54,9 +55,28 @@ GRANT ALL PRIVILEGES ON DATABASE gender_reveal TO gender_reveal_user;
 ALTER ROLE gender_reveal_user CREATEDB;
 \q
 
+# Run Prisma migrations & seed data
 npx prisma migrate dev -n initial_database
 npx prisma db seed
-
 npx prisma generate
-
 ```
+
+## Running Locally
+
+```bash
+npm install
+npm run dev             # Next.js dev server
+# or
+npm start               # Runs node server.mjs in production mode
+```
+
+## Screenshots
+
+<!--
+![Landing](docs/screenshot1.png)
+![Quiz Screen](docs/screenshot2.png)
+![Termo Screen](docs/screenshot3.png)
+-->
+
+(Replace the placeholders with actual images of the application.)
+


### PR DESCRIPTION
## Summary
- describe app flow with host and player sessions for quiz and termo games
- document websocket limitations on Vercel and custom server
- add database setup, migration, and seed instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7962d6dd08323805c61ed946647aa